### PR TITLE
Functional components returning conditionals fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,7 +142,9 @@ function doesReturnJSX (body) {
     var lastBlock = block.slice(0).pop()
 
     if (lastBlock.type === 'ReturnStatement') {
-      return lastBlock.argument !== null && lastBlock.argument.type === 'JSXElement'
+        return lastBlock.argument !== null && (lastBlock.argument.type === 'JSXElement' ||
+            (lastBlock.argument.type === 'ConditionalExpression' &&
+            (lastBlock.argument.consequent.type === 'JSXElement' || lastBlock.argument.alternate.type === 'JSXElement')))
     }
   }
 

--- a/test/fixtures/functionExpr/expected.js
+++ b/test/fixtures/functionExpr/expected.js
@@ -57,4 +57,14 @@ export default function Component1f(value) {
     value
   );
 }
+
 Component1f.displayName = "Component1f";
+// Exported named stateless component used in variable declaration returning conditional JSX
+export var Component1g = function (value) {
+  return true ? React.createElement(
+    "div",
+    null,
+    value
+  ) : null;
+};
+Component1g.displayName = "Component1g";

--- a/test/fixtures/functionExpr/input.js
+++ b/test/fixtures/functionExpr/input.js
@@ -28,3 +28,8 @@ Component1e = function (value) {
 export default function Component1f (value) {
   return <div>{value}</div>
 }
+
+// Exported named stateless component used in variable declaration returning conditional JSX
+export var Component1g = function (value) {
+    return true ? <div>{value}</div> : null
+}


### PR DESCRIPTION
* fixing an issue where the displayname was not being added to functional components that returned conditionals

Ex: If we have some functional component:
```
function MyComponent(props) {
  return props.someBoolean ? (<div>something</div>) : null
}
```
A `displayName` would not be added to this component without this fix.